### PR TITLE
Point at gsm.core@dev for new lSource data and dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
   riskmetric,
   testthat (>= 3.0.0)
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@main
+    gsm.core=Gilead-BioStats/gsm.core@fix-130
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Config/testthat/parallel: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
   riskmetric,
   testthat (>= 3.0.0)
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@fix-130
+    gsm.core=Gilead-BioStats/gsm.core@dev
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Config/testthat/parallel: false

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can install the development version of `gsm.qtl` like so:
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.qtl@dev")
+pak::pak("Gilead-BioStats/gsm.qtl@for-gsm.kri-193")
 ```
 
 ## Sample Code

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can install the development version of `gsm.qtl` like so:
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.qtl@for-gsm.kri-193")
+pak::pak("Gilead-BioStats/gsm.qtl@dev")
 ```
 
 ## Sample Code


### PR DESCRIPTION
## Summary
- Point at gsm.core@dev for new lSource data and dependencies

## Why
- gsm.kri depends on this package, and requires the update to gsm.core, so this prevents dependency conflicts

## Files changed
- DESCRIPTION

## Tests run (exact commands)
- 

## Risk / rollback
- 

## Follow-ups
- 
