### PR TITLE
Fix eligibility_listing crash on zero-row or all-NA input

### DIFF
--- a/R/eligibility_listing.R
+++ b/R/eligibility_listing.R
@@ -5,18 +5,26 @@
 #' @returns A `gt` object or `data.frame`
 #' @export
 eligibility_listing <- function(df, download = FALSE) {
+  if (nrow(df) == 0) {
+    if (download) return(df)
+    return(gt::gt(df))
+  }
+
+  n_dvdtm <- max(sapply(strsplit(na.omit(df$dvdtm), ";;;"), length), 1L)
+  n_elig <- max(sapply(strsplit(na.omit(df$eligibility_criteria), ";;;"), length), 1L)
+
   listing <- df %>%
     select(country, invid, subjid, Source, ietestcd_concat, dvdtm, eligibility_criteria) %>%
     tidyr::separate(
       dvdtm,
-      into = paste0("PD Date", seq_len(max(sapply(strsplit(df$dvdtm, ";;;"), length)))),
+      into = paste0("PD Date", seq_len(n_dvdtm)),
       sep = ";;;",
       fill = "right"
     ) %>%
     mutate_at(vars(starts_with("PD Date")), ~ substr(.x, 1, 10)) %>%
     tidyr::separate(
       eligibility_criteria,
-      into = paste0("PD Term", seq_len(max(sapply(strsplit(df$eligibility_criteria, ";;;"), length)))),
+      into = paste0("PD Term", seq_len(n_elig)),
       sep = ";;;",
       fill = "right"
     ) %>%

--- a/R/eligibility_listing.R
+++ b/R/eligibility_listing.R
@@ -10,8 +10,11 @@ eligibility_listing <- function(df, download = FALSE) {
     return(gt::gt(df))
   }
 
-  n_dvdtm <- max(sapply(strsplit(na.omit(df$dvdtm), ";;;"), length), 1L)
-  n_elig <- max(sapply(strsplit(na.omit(df$eligibility_criteria), ";;;"), length), 1L)
+  dvdtm_splits <- strsplit(na.omit(df$dvdtm), ";;;")
+  n_dvdtm <- if (length(dvdtm_splits) == 0) 1L else max(lengths(dvdtm_splits))
+
+  elig_splits <- strsplit(na.omit(df$eligibility_criteria), ";;;")
+  n_elig <- if (length(elig_splits) == 0) 1L else max(lengths(elig_splits))
 
   listing <- df %>%
     select(country, invid, subjid, Source, ietestcd_concat, dvdtm, eligibility_criteria) %>%

--- a/tests/testthat/test-exported-eligibility.R
+++ b/tests/testthat/test-exported-eligibility.R
@@ -142,6 +142,31 @@ test_that("eligibility_listing covers df and download arguments (#21, #22, #24, 
   expect_true(nrow(out_download) > 0)
 })
 
+test_that("eligibility_listing handles zero-row data frame (#108)", {
+  df <- qtl_test_participant_df()[0, ]
+
+  out_download <- eligibility_listing(df = df, download = TRUE)
+  out_gt <- eligibility_listing(df = df, download = FALSE)
+
+  expect_s3_class(out_download, "data.frame")
+  expect_equal(nrow(out_download), 0)
+  expect_s3_class(out_gt, "gt_tbl")
+})
+
+test_that("eligibility_listing handles all-NA dvdtm and eligibility_criteria (#108)", {
+  df <- tibble::tribble(
+    ~invid, ~country, ~subjid, ~Source, ~ietestcd_concat, ~dvdtm, ~eligibility_criteria, ~compyn, ~compreas,
+    "S01", "US", "SUBJ-001", "EDC", "I001", NA_character_, NA_character_, "N", "AE"
+  )
+
+  out <- eligibility_listing(df = df, download = TRUE)
+
+  expect_s3_class(out, "data.frame")
+  expect_equal(nrow(out), 1)
+  expect_true("PD Date1" %in% names(out))
+  expect_true("PD Term1" %in% names(out))
+})
+
 test_that("scrollable_gt uses height and width arguments (#21, #22)", {
   gt_tbl <- gt::gt(head(qtl_test_participant_df(), 2))
   out <- scrollable_gt(gt_tbl = gt_tbl, height = "200px", min_table_width = "800px")


### PR DESCRIPTION
## Summary
- Adds early return for zero-row `df` to prevent crash in `eligibility_listing()`
- Guards `max(sapply(strsplit(...)))` with `na.omit()` and a fallback of `1L` to handle all-`NA` columns

Closes #108