### PR TITLE
Fix 118: Standardize activity fields

### DIFF
--- a/inst/workflow/0_other/disc_reasons.yaml
+++ b/inst/workflow/0_other/disc_reasons.yaml
@@ -3,6 +3,7 @@ meta:
   ID: disc_reasons
   file: disc_reasons.yaml
   output: string
+  Active: true
 steps:
   - output: disc_reasons
     name: c

--- a/inst/workflow/2_metrics/qtl0001.yaml
+++ b/inst/workflow/2_metrics/qtl0001.yaml
@@ -11,8 +11,7 @@ meta:
   AnalysisType: binary
   nPropRate: 0.03 # insert historical data
   nNumDeviations: 3
-  MetricActive: true
-  WorkItemActive: true
+  Active: true
 spec:
   Mapped_EXCLUSION:
     subjid:

--- a/inst/workflow/2_metrics/qtl0001.yaml
+++ b/inst/workflow/2_metrics/qtl0001.yaml
@@ -12,6 +12,7 @@ meta:
   nPropRate: 0.03 # insert historical data
   nNumDeviations: 3
   Active: true
+  GenerateRiskSignal: true
 spec:
   Mapped_EXCLUSION:
     subjid:

--- a/inst/workflow/2_metrics/qtl0002.yaml
+++ b/inst/workflow/2_metrics/qtl0002.yaml
@@ -12,6 +12,7 @@ meta:
   nPropRate: 0.07 # insert historical data
   nNumDeviations: 3
   Active: true
+  GenerateRiskSignal: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/2_metrics/qtl0002.yaml
+++ b/inst/workflow/2_metrics/qtl0002.yaml
@@ -11,8 +11,7 @@ meta:
   AnalysisType: binary
   nPropRate: 0.07 # insert historical data
   nNumDeviations: 3
-  MetricActive: true
-  WorkItemActive: true
+  Active: true
 spec:
   Mapped_SUBJ:
     subjid:

--- a/inst/workflow/4_modules/report_qtl.yaml
+++ b/inst/workflow/4_modules/report_qtl.yaml
@@ -4,6 +4,7 @@ meta:
   Output: html
   Name: QTL Report
   Description: A report summarizing QTL
+  Active: true
 spec:
   Mapped_STUDCOMP:
     _all:


### PR DESCRIPTION
## Summary
The updated design for Gilead-BioStats/gsm.roadmap#55 calls for an `Active` field on all workflows (but `true` by default, so technically it doesn't matter whether it's there or not, other than making it easy to flip it to `false`). Separately, `GenerateSignal: false` will "turn off" the ADO portion in {grail}, but that's Gilead-specific, so I'm leaving it out of the default workflows.

- Add `Active: true` to all workflows
- Add `GenerateRiskSignal: true` to metric workflows
- Remove `MetricActive: true` and `WorkItemActive: true` fields

- Closes #118.

## Why

## Files changed

## Tests run (exact commands)

## Risk / rollback

## Follow-ups
