### PR TITLE
Fix 124: Remove unused riskmetric package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,11 +30,9 @@ Imports:
     purrr,
     rlang,
     scales,
-    stats,
     stringr,
     tibble,
     tidyr,
-    utils,
     workr,
     yaml
 Suggests: 
@@ -46,7 +44,6 @@ Suggests:
     lubridate,
     pander,
     qcthat,
-    riskmetric,
     rmarkdown,
     testthat (>= 3.0.0)
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ VignetteBuilder:
 Remotes:
     gsm.core=Gilead-BioStats/gsm.core@eliminate-log4r,
     workr=Gilead-BioStats/workr@main,
-    qcthat=Gilead-BioStats/qcthat@main
+    qcthat=Gilead-BioStats/qcthat@*release
 Config/Needs/website: DT, here, pkgdown, devtools
 Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Suggests:
     lubridate,
     pander,
     qcthat,
+    riskmetric,
     rmarkdown,
     testthat (>= 3.0.0)
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsm.qtl
 Title: Good Statistical Monitoring QTLs
-Version: 1.3.0
+Version: 1.3.0.9000
 Authors@R: c(
     person("Zhongkai", "Wang", , "Zhongkai.Wang6@gilead.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1883-2265")),
@@ -51,7 +51,7 @@ VignetteBuilder:
 Remotes:
     gsm.core=Gilead-BioStats/gsm.core@main,
     workr=Gilead-BioStats/workr@main,
-    qcthat=Gilead-BioStats/qcthat@*release
+    qcthat=Gilead-BioStats/qcthat@main
 Config/Needs/website: DT, here, pkgdown, devtools
 Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,8 +49,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gh=r-lib/gh,
-    gsm.core=Gilead-BioStats/gsm.core@main,
+    gsm.core=Gilead-BioStats/gsm.core@eliminate-log4r,
     workr=Gilead-BioStats/workr@main,
     qcthat=Gilead-BioStats/qcthat@main
 Config/Needs/website: DT, here, pkgdown, devtools

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@eliminate-log4r,
+    gsm.core=Gilead-BioStats/gsm.core@dev,
     workr=Gilead-BioStats/workr@main,
     qcthat=Gilead-BioStats/qcthat@*release
 Config/Needs/website: DT, here, pkgdown, devtools

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,6 @@ Imports:
     stringr,
     tibble,
     tidyr,
-    workr,
     yaml
 Suggests: 
     cli,
@@ -44,9 +43,9 @@ Suggests:
     lubridate,
     pander,
     qcthat,
-    riskmetric,
     rmarkdown,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    workr
 VignetteBuilder: 
     knitr
 Remotes:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,6 +49,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
+    gh=r-lib/gh,
     gsm.core=Gilead-BioStats/gsm.core@main,
     workr=Gilead-BioStats/workr@main,
     qcthat=Gilead-BioStats/qcthat@main

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# gsm.qtl (development version)
+
 # gsm.qtl v1.3.0
 
 ### Key Enhancements:

--- a/vignettes/articles/Qualification.Rmd
+++ b/vignettes/articles/Qualification.Rmd
@@ -24,6 +24,7 @@ suppressPackageStartupMessages({
   library(pander)
   library(gh)
   library(stringr)
+  library(riskmetric)
   suppressMessages(devtools::load_all())
 })
 

--- a/vignettes/articles/Qualification.Rmd
+++ b/vignettes/articles/Qualification.Rmd
@@ -24,7 +24,6 @@ suppressPackageStartupMessages({
   library(pander)
   library(gh)
   library(stringr)
-  library(riskmetric)
   suppressMessages(devtools::load_all())
 })
 


### PR DESCRIPTION
The riskmetric package has pak as a dependency, which currently causes issues (while pak is [broken](https://github.com/r-lib/pak/issues/900), pending release of 0.11.1 or higher). This isn't always an issue, but it currently causes this PR's actions to fail, I *think* because it's targeting specific branches of packages (ie, I think that's why the action is specifically trying to update pak). It's good to remove unused packages anyway, though, and I couldn't see anything that riskmetric was doing in here.

I also removed `stats` and `utils` (core packages don't need to show up in `DESCRIPTION` and can cause weirdness when they do, it turns out), and moved `workr` to `Suggests` (it's in `Imports` for `gsm.core`, though, so it gets installed regardless; this stops R CMD check from complaining about it, though).

Note: `gsm.core`'s entry in `Remotes:` should be changed to `@dev` after [this PR](https://github.com/Gilead-BioStats/gsm.core/pull/162) merges (before this gsm.qtl PR merges), and then to `main` when gsm.qtl is ready for release.

- Closes #124