### PR TITLE
fix: update Gilead-BioStats links to Gilead-Public

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to the `gsm` suite of packages!
 
-This repository follows the **centralized `gsm` Contributor Guidelines** maintained in [`gsm.core`](https://gilead-biostats.github.io/gsm.core/CONTRIBUTING.html).  
+This repository follows the **centralized `gsm` Contributor Guidelines** maintained in [`gsm.core`](https://gilead-public.github.io/gsm.core/CONTRIBUTING.html).  
 Please review those guidelines before opening issues or submitting pull requests.
 
 ## Key Points
@@ -12,4 +12,4 @@ Please review those guidelines before opening issues or submitting pull requests
 - Track your issue on the [`gsm` Roadmap Project Board](https://github.com/orgs/Gilead-BioStats/projects/41).  
 - All code changes should be made in a branch and submitted as a PR following the guidelines linked above.  
   
-For detailed workflows (branching, releases, QC, CI/CD), please see the full [Contributor Guidelines in gsm.core](https://gilead-biostats.github.io/gsm.core/CONTRIBUTING.html).
+For detailed workflows (branching, releases, QC, CI/CD), please see the full [Contributor Guidelines in gsm.core](https://gilead-public.github.io/gsm.core/CONTRIBUTING.html).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,9 +12,9 @@ Description: The Good Statistical Monitoring or 'gsm' suite of R packages
     extension that contains the additional functions, workflows, and
     document template to generate reports for QTL.
 License: Apache License (>= 2)
-URL: https://gilead-biostats.github.io/gsm.qtl,
-    https://github.com/Gilead-BioStats/gsm.qtl,
-BugReports: https://github.com/Gilead-BioStats/gsm.qtl/issues
+URL: https://gilead-public.github.io/gsm.qtl,
+    https://github.com/Gilead-Public/gsm.qtl,
+BugReports: https://github.com/Gilead-Public/gsm.qtl/issues
 Depends:
     R (>= 4.0)
 Imports: 
@@ -49,9 +49,9 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@dev,
-    workr=Gilead-BioStats/workr@main,
-    qcthat=Gilead-BioStats/qcthat@*release
+    gsm.core=Gilead-Public/gsm.core@dev,
+    workr=Gilead-Public/workr@main,
+    qcthat=Gilead-Public/qcthat@*release
 Config/Needs/website: DT, here, pkgdown, devtools
 Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 <div class="pkgdown-release">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
 <div class="pkgdown-devel">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
@@ -23,11 +23,11 @@
 # Good Statistical Monitoring QTL `{gsm.qtl}` R package
 
 
-This README provides a high-level overview of `gsm.qtl`; see the [package website](https://gilead-biostats.github.io/gsm.qtl/) for additional details.
+This README provides a high-level overview of `gsm.qtl`; see the [package website](https://gilead-public.github.io/gsm.qtl/) for additional details.
 
 The Good Statistical Monitoring or `gsm` suite of R packages provides a framework for statistical data monitoring. 
 `gsm.qtl` is an extension package that contains the additional functions, workflows, and document template to generate reports for quality tolerance limits (QTL).
-See [`gsm.core`](https://github.com/Gilead-BioStats/gsm.core) for an overview of the ecosystem.
+See [`gsm.core`](https://github.com/Gilead-Public/gsm.core) for an overview of the ecosystem.
 
 # Background 
 
@@ -36,12 +36,12 @@ such as inclusion/exclusion criteria violations, early study discontinuation, et
 
 # Mapping
 
-Datasets necessary to calculate a particular QTL can be requested or customized based off of previously existing mappings, see [`gsm.mapping`](https://github.com/Gilead-BioStats/gsm.mapping).
+Datasets necessary to calculate a particular QTL can be requested or customized based off of previously existing mappings, see [`gsm.mapping`](https://github.com/Gilead-Public/gsm.mapping).
 Additional mappings that have been added to support `gsm.qtl` include the `IE` and `EXCLUSION` mappings.
 
 # Metrics
 
-`qtlxxxx` metric yaml files have been added to calculate study level QTLs, these files follow similar structure to those found in [`gsm.kri`](https://github.com/Gilead-BioStats/gsm.kri).
+`qtlxxxx` metric yaml files have been added to calculate study level QTLs, these files follow similar structure to those found in [`gsm.kri`](https://github.com/Gilead-Public/gsm.kri).
 
 # Reporting
 
@@ -53,7 +53,7 @@ You can install the latest release of gsm.qtl from [GitHub](https://github.com/)
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.qtl@*release")
+pak::pak("Gilead-Public/gsm.qtl@*release")
 ```
 
 <div class="pkgdown-devel">
@@ -63,7 +63,7 @@ You can install the development version of gsm.qtl from
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.qtl")
+pak::pak("Gilead-Public/gsm.qtl")
 ```
 
 </div>

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://gilead-biostats.github.io/gsm.qtl
+url: https://gilead-public.github.io/gsm.qtl
 template:
   bootstrap: 5
   bootswatch: yeti

--- a/data-raw/Example_QTL.R
+++ b/data-raw/Example_QTL.R
@@ -65,7 +65,7 @@ mapped <- map(mapped, ~ {
 analyzed <- map_depth(mapped, 1, ~workr::RunWorkflows(metrics_wf, .x))
 reporting <- map2(mapped, analyzed, ~ workr::RunWorkflows(reporting_wf, c(.x, list(lAnalyzed = .y, lWorkflows = metrics_wf))))
 
-# Fix `SnapshotDate` column in reporting results, can be addressed in https://github.com/Gilead-BioStats/gsm.reporting/issues/24
+# Fix `SnapshotDate` column in reporting results, can be addressed in https://github.com/Gilead-Public/gsm.reporting/issues/24
 dates <- names(ie_data) %>% as.Date
 reporting <- map2(reporting, dates, ~{
   .x$Reporting_Results$SnapshotDate <- .y

--- a/man/gsm.qtl-package.Rd
+++ b/man/gsm.qtl-package.Rd
@@ -11,9 +11,9 @@ The Good Statistical Monitoring or 'gsm' suite of R packages provides a framewor
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://gilead-biostats.github.io/gsm.qtl}
-  \item \url{https://github.com/Gilead-BioStats/gsm.qtl},
-  \item Report bugs at \url{https://github.com/Gilead-BioStats/gsm.qtl/issues}
+  \item \url{https://gilead-public.github.io/gsm.qtl}
+  \item \url{https://github.com/Gilead-Public/gsm.qtl,}
+  \item Report bugs at \url{https://github.com/Gilead-Public/gsm.qtl/issues}
 }
 
 }
@@ -22,7 +22,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Zhongkai Wang \email{Zhongkai.Wang6@gilead.com} (\href{https://orcid.org/0000-0002-1883-2265}{ORCID})
   \item Laura Maxwell \email{laura.maxwell@atorusresearch.com}
   \item Zelos Zhu \email{zelos.zhu@atorusresearch.com}
 }

--- a/pkgdown/menus/examples/Example_QTL.Rmd
+++ b/pkgdown/menus/examples/Example_QTL.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "QTL Report"
-author: "[gsm.qtl](https://gilead-biostats.github.io/gsm.qtl) Example"
+author: "[gsm.qtl](https://gilead-public.github.io/gsm.qtl) Example"
 description: "Example of a QTL Report generated using standard QTLs in gsm.kri"
 index: 1
 date: "`r format(Sys.time(), '%B %d, %Y %H:%M:%S %Z')`"

--- a/vignettes/articles/Qualification.Rmd
+++ b/vignettes/articles/Qualification.Rmd
@@ -194,20 +194,20 @@ pander::pandoc.p('\\pagebreak')
 
 # Pull Request History
 
-The GitHub Pull Request (PR) process begins with the creation of one or more issues that clearly define the proposed additions or revisions to the package. Each issue should be assigned to a product developer (PD) who then creates a `fix` branch named according to the related issue(s), and implements the necessary code updates. Once the work is complete, the PD opens a Pull Request to merge the `fix` branch into the target branch (typically the `dev` branch). They must assign the PR to themselves, request one or more reviewers, and link the PR to the associated issue(s). Before the fix branch can be merged, the PR must be approved by the designated reviewers and pass all required GitHub qualification checks. Once these conditions are met, the `fix` branch is merged into the target branch. This process is fully documented in the [Contributor Guidelines](https://gilead-biostats.github.io/gsm.core/articles/ContributorGuidelines.html#development-process)
+The GitHub Pull Request (PR) process begins with the creation of one or more issues that clearly define the proposed additions or revisions to the package. Each issue should be assigned to a product developer (PD) who then creates a `fix` branch named according to the related issue(s), and implements the necessary code updates. Once the work is complete, the PD opens a Pull Request to merge the `fix` branch into the target branch (typically the `dev` branch). They must assign the PR to themselves, request one or more reviewers, and link the PR to the associated issue(s). Before the fix branch can be merged, the PR must be approved by the designated reviewers and pass all required GitHub qualification checks. Once these conditions are met, the `fix` branch is merged into the target branch. This process is fully documented in the [Contributor Guidelines](https://gilead-public.github.io/gsm.core/articles/ContributorGuidelines.html#development-process)
 
 
 Below, the most recent 10 PRs into `r params$repo` are displayed. [See all Pull Requests here.](`r paste0("https://github.com/gilead-biostats/",params$repo,"/pulls")`)
 
 ```{r prs}
-release <- gh(paste0("/repos/Gilead-BioStats/",params$repo,"/releases"))[[1]]
+release <- gh(paste0("/repos/Gilead-Public/",params$repo,"/releases"))[[1]]
 release_date <- ifelse(is.null(release$published_at), release$created_at, release$published_at)
 
 pr_at_date <- FALSE
 page_num <- 1
 prs <- list()
 while(pr_at_date != TRUE){
-  resp <- gh(paste0("/repos/Gilead-BioStats/",params$repo,"/pulls"), per_page = 100,
+  resp <- gh(paste0("/repos/Gilead-Public/",params$repo,"/pulls"), per_page = 100,
              .params = list(page = page_num, state = "closed"))
 
   map(resp, function(x){
@@ -240,7 +240,7 @@ getRepoDetails <- function(x) {
   Link <- x[["html_url"]]
 
 
-  tempReviews <- gh(paste0("GET /repos/Gilead-BioStats/", params$repo, "/pulls/", PullRequest, "/reviews"))
+  tempReviews <- gh(paste0("GET /repos/Gilead-Public/", params$repo, "/pulls/", PullRequest, "/reviews"))
 
   if (length(tempReviews) > 0) {
   ReviewStatus <- tempReviews[[1]][["state"]]


### PR DESCRIPTION
## Summary
Updates all direct `Gilead-BioStats` org links to `Gilead-Public` across docs, config, and metadata files.

## Changes
- Replaced `github.com/Gilead-BioStats` → `github.com/Gilead-Public` in all applicable files.
- Replaced `gilead-biostats.github.io` → `gilead-public.github.io` in all applicable files.
- Updated GitHub API org references in `vignettes/articles/Qualification.Rmd` (`/repos/Gilead-BioStats/` → `/repos/Gilead-Public/`).

## Intentional non-updated links
- `NEWS.md` line 28 — historical changelog PR link.
- `orgs/Gilead-BioStats/projects/41` in `.github/CONTRIBUTING.md` and issue templates — org-level project board.

## Validation
- `grep -rn "Gilead-BioStats\|gilead-biostats.github.io" --exclude-dir=man --exclude-dir=docs --exclude-dir=gsm.qtl.Rcheck .` returns only the intentional keeps listed above.

Closes #132