### PR TITLE
gsm.qtl v1.3.1 RC

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^\.positai$
 ^\.claude$
 ^AGENTS\.md$
+^data-raw$

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to the `gsm` suite of packages!
 
-This repository follows the **centralized `gsm` Contributor Guidelines** maintained in [`gsm.core`](https://gilead-biostats.github.io/gsm.core/CONTRIBUTING.html).  
+This repository follows the **centralized `gsm` Contributor Guidelines** maintained in [`gsm.core`](https://gilead-public.github.io/gsm.core/CONTRIBUTING.html).  
 Please review those guidelines before opening issues or submitting pull requests.
 
 ## Key Points
@@ -12,4 +12,4 @@ Please review those guidelines before opening issues or submitting pull requests
 - Track your issue on the [`gsm` Roadmap Project Board](https://github.com/orgs/Gilead-BioStats/projects/41).  
 - All code changes should be made in a branch and submitted as a PR following the guidelines linked above.  
   
-For detailed workflows (branching, releases, QC, CI/CD), please see the full [Contributor Guidelines in gsm.core](https://gilead-biostats.github.io/gsm.core/CONTRIBUTING.html).
+For detailed workflows (branching, releases, QC, CI/CD), please see the full [Contributor Guidelines in gsm.core](https://gilead-public.github.io/gsm.core/CONTRIBUTING.html).

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,5 +1,5 @@
 # name: R-CMD-check.yaml
-# version: 0.4.2
+# version: 1.0.0
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Description: R CMD check for PRs
 on:
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Define matrix based on target branch
         id: set-matrix
-        uses: gilead-biostats/gsm.utils/setup-matrix-with-dev@actions-v1
+        uses: gilead-public/gsm.utils/setup-matrix-with-dev@actions-v1
         with:
           pkg-use: 'public'
   R-CMD-check:
@@ -32,18 +32,18 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
     steps:
       - name: Generate token
-        uses: gilead-biostats/gsm.utils/generate-token@actions-v1
+        uses: gilead-public/gsm.utils/generate-token@actions-v1
         id: token
         with:
           app-id: ${{ secrets.CM_BOT_APP_ID }}
           app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Check out repo
-        uses: gilead-biostats/gsm.utils/checkout@actions-v1
+        uses: gilead-public/gsm.utils/checkout@actions-v1
         with:
           token: ${{ steps.token.outputs.token }}
       - name: Install R and dependencies
-        uses: gilead-biostats/gsm.utils/install@actions-v1
+        uses: gilead-public/gsm.utils/install@actions-v1
         with:
           token: ${{ steps.token.outputs.token }}
           r-version: ${{ matrix.config.r }}
@@ -55,6 +55,6 @@ jobs:
         shell: bash
         run: echo "GITHUB_PAT=${{ steps.token.outputs.token }}" >> $GITHUB_ENV
       - name: Check package
-        uses: gilead-biostats/gsm.utils/check-r-package@actions-v1
+        uses: gilead-public/gsm.utils/check-r-package@actions-v1
         with:
           error-on: ${{ matrix.config.error-on || '"warning"' }}

--- a/.github/workflows/pkgdown-all.yaml
+++ b/.github/workflows/pkgdown-all.yaml
@@ -1,5 +1,5 @@
 # name: pkgdown-all.yaml
-# version: 0.4.1
+# version: 1.0.0
 # Description: Triggers the core pkgdown deployment and cleanup workflows.
 name: pkgdown-all
 on:
@@ -29,7 +29,7 @@ permissions:
   pull-requests: write
 jobs:
   call-pkgdown-core:
-    uses: Gilead-BioStats/gsm.utils/.github/workflows/pkgdown-core.yaml@actions-v1
+    uses: gilead-public/gsm.utils/.github/workflows/pkgdown-core.yaml@actions-v1
     with:
       # These inputs only actually matter for workflow_dispatch; otherwise
       # they're automatically determined.

--- a/.github/workflows/qcthat.yaml
+++ b/.github/workflows/qcthat.yaml
@@ -1,5 +1,5 @@
 # name: qcthat.yaml
-# version: 0.2.1
+# version: 0.2.2
 # Description: Generate qcthat quality control reports for pull requests and releases and manage user acceptance testing.
 on:
   pull_request:
@@ -40,7 +40,7 @@ jobs:
     if: >-
       (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'qcthat-uat')) ||
       github.event_name != 'issues'
-    uses: Gilead-BioStats/qcthat/.github/workflows/qcthat-core.yaml@actions
+    uses: gilead-public/qcthat/.github/workflows/qcthat-core.yaml@actions
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       qcthat-app-id: ${{ secrets.CM_BOT_APP_ID }}

--- a/.github/workflows/r-releaser-caller.yaml
+++ b/.github/workflows/r-releaser-caller.yaml
@@ -1,5 +1,5 @@
 # name: r-releaser-caller.yaml
-# version: 0.4.1
+# version: 1.0.0
 # Description: R package release workflow
 name: Release
 
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   call-release-workflow:
-    uses: Gilead-BioStats/gsm.utils/.github/workflows/r-releaser.yaml@actions-v1
+    uses: gilead-public/gsm.utils/.github/workflows/r-releaser.yaml@actions-v1
     with:
       tag: ${{ github.event.release.tag_name || inputs.tag }}
     secrets:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,5 +1,5 @@
 # name: test-coverage.yaml
-# version: 0.4.1
+# version: 1.0.0
 # Description: Compute test coverage and publish coverage-summary.json artifact
 name: test-coverage
 on:
@@ -18,7 +18,7 @@ permissions:
   pull-requests: write
 jobs:
   call-test-coverage-core:
-    uses: Gilead-BioStats/gsm.utils/.github/workflows/test-coverage-core.yaml@actions-v1
+    uses: gilead-public/gsm.utils/.github/workflows/test-coverage-core.yaml@actions-v1
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       app-id: ${{ secrets.CM_BOT_APP_ID }}

--- a/.github/workflows/workflow-template-check.yaml
+++ b/.github/workflows/workflow-template-check.yaml
@@ -1,5 +1,5 @@
 # name: workflow-template-check.yaml
-# version: 0.5.0
+# version: 1.0.0
 # Description: Check if GitHub Actions workflows match gsm.utils templates
 name: Workflow Template Compliance Check
 on:
@@ -16,7 +16,7 @@ permissions:
   contents: write
 jobs:
   check-workflows:
-    uses: Gilead-BioStats/gsm.utils/.github/workflows/workflow-template-checker.yaml@actions-v1
+    uses: gilead-public/gsm.utils/.github/workflows/workflow-template-checker.yaml@actions-v1
     with:
       default-branch: ${{ github.event.repository.default_branch }}
       pr-number: '${{ github.event.number }}'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsm.qtl
 Title: Good Statistical Monitoring QTLs
-Version: 1.3.0
+Version: 1.3.0.9000
 Authors@R: c(
     person("Zhongkai", "Wang", , "Zhongkai.Wang6@gilead.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1883-2265")),
@@ -30,12 +30,9 @@ Imports:
     purrr,
     rlang,
     scales,
-    stats,
     stringr,
     tibble,
     tidyr,
-    utils,
-    workr,
     yaml
 Suggests: 
     cli,
@@ -46,13 +43,13 @@ Suggests:
     lubridate,
     pander,
     qcthat,
-    riskmetric,
     rmarkdown,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    workr
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@main,
+    gsm.core=Gilead-BioStats/gsm.core@dev,
     workr=Gilead-BioStats/workr@main,
     qcthat=Gilead-BioStats/qcthat@*release
 Config/Needs/website: DT, here, pkgdown, devtools

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,9 +12,9 @@ Description: The Good Statistical Monitoring or 'gsm' suite of R packages
     extension that contains the additional functions, workflows, and
     document template to generate reports for QTL.
 License: Apache License (>= 2)
-URL: https://gilead-biostats.github.io/gsm.qtl,
-    https://github.com/Gilead-BioStats/gsm.qtl,
-BugReports: https://github.com/Gilead-BioStats/gsm.qtl/issues
+URL: https://gilead-public.github.io/gsm.qtl,
+    https://github.com/Gilead-Public/gsm.qtl,
+BugReports: https://github.com/Gilead-Public/gsm.qtl/issues
 Depends:
     R (>= 4.0)
 Imports: 
@@ -49,9 +49,9 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@dev,
-    workr=Gilead-BioStats/workr@main,
-    qcthat=Gilead-BioStats/qcthat@*release
+    gsm.core=Gilead-Public/gsm.core@dev,
+    workr=Gilead-Public/workr@main,
+    qcthat=Gilead-Public/qcthat@*release
 Config/Needs/website: DT, here, pkgdown, devtools
 Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsm.qtl
 Title: Good Statistical Monitoring QTLs
-Version: 1.3.0.9000
+Version: 1.3.1
 Authors@R: c(
     person("Zhongkai", "Wang", , "Zhongkai.Wang6@gilead.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1883-2265")),
@@ -49,7 +49,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-Public/gsm.core@dev,
+    gsm.core=Gilead-Public/gsm.core@main,
     workr=Gilead-Public/workr@main,
     qcthat=Gilead-Public/qcthat@*release
 Config/Needs/website: DT, here, pkgdown, devtools

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# gsm.qtl (development version)
+
 # gsm.qtl v1.3.0
 
 ### Key Enhancements:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gsm.qtl v1.3.1
 
-This patch release removes the log4r package dependency, because the log4r package was archived on CRAN (#124)
+This patch release removes an unused dependency that had a dependency on the log4r package, because the log4r package was archived on CRAN (#124)
 
 # gsm.qtl v1.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gsm.qtl (development version)
+# gsm.qtl v1.3.1
+
+This patch release removes the log4r package dependency, because the log4r package was archived on CRAN (#124)
 
 # gsm.qtl v1.3.0
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 <div class="pkgdown-release">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
 <div class="pkgdown-devel">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.qtl/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.qtl/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
@@ -23,11 +23,11 @@
 # Good Statistical Monitoring QTL `{gsm.qtl}` R package
 
 
-This README provides a high-level overview of `gsm.qtl`; see the [package website](https://gilead-biostats.github.io/gsm.qtl/) for additional details.
+This README provides a high-level overview of `gsm.qtl`; see the [package website](https://gilead-public.github.io/gsm.qtl/) for additional details.
 
 The Good Statistical Monitoring or `gsm` suite of R packages provides a framework for statistical data monitoring. 
 `gsm.qtl` is an extension package that contains the additional functions, workflows, and document template to generate reports for quality tolerance limits (QTL).
-See [`gsm.core`](https://github.com/Gilead-BioStats/gsm.core) for an overview of the ecosystem.
+See [`gsm.core`](https://github.com/Gilead-Public/gsm.core) for an overview of the ecosystem.
 
 # Background 
 
@@ -36,12 +36,12 @@ such as inclusion/exclusion criteria violations, early study discontinuation, et
 
 # Mapping
 
-Datasets necessary to calculate a particular QTL can be requested or customized based off of previously existing mappings, see [`gsm.mapping`](https://github.com/Gilead-BioStats/gsm.mapping).
+Datasets necessary to calculate a particular QTL can be requested or customized based off of previously existing mappings, see [`gsm.mapping`](https://github.com/Gilead-Public/gsm.mapping).
 Additional mappings that have been added to support `gsm.qtl` include the `IE` and `EXCLUSION` mappings.
 
 # Metrics
 
-`qtlxxxx` metric yaml files have been added to calculate study level QTLs, these files follow similar structure to those found in [`gsm.kri`](https://github.com/Gilead-BioStats/gsm.kri).
+`qtlxxxx` metric yaml files have been added to calculate study level QTLs, these files follow similar structure to those found in [`gsm.kri`](https://github.com/Gilead-Public/gsm.kri).
 
 # Reporting
 
@@ -53,7 +53,7 @@ You can install the latest release of gsm.qtl from [GitHub](https://github.com/)
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.qtl@*release")
+pak::pak("Gilead-Public/gsm.qtl@*release")
 ```
 
 <div class="pkgdown-devel">
@@ -63,7 +63,7 @@ You can install the development version of gsm.qtl from
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.qtl")
+pak::pak("Gilead-Public/gsm.qtl")
 ```
 
 </div>

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://gilead-biostats.github.io/gsm.qtl
+url: https://gilead-public.github.io/gsm.qtl
 template:
   bootstrap: 5
   bootswatch: yeti

--- a/data-raw/Example_QTL.R
+++ b/data-raw/Example_QTL.R
@@ -65,7 +65,7 @@ mapped <- map(mapped, ~ {
 analyzed <- map_depth(mapped, 1, ~workr::RunWorkflows(metrics_wf, .x))
 reporting <- map2(mapped, analyzed, ~ workr::RunWorkflows(reporting_wf, c(.x, list(lAnalyzed = .y, lWorkflows = metrics_wf))))
 
-# Fix `SnapshotDate` column in reporting results, can be addressed in https://github.com/Gilead-BioStats/gsm.reporting/issues/24
+# Fix `SnapshotDate` column in reporting results, can be addressed in https://github.com/Gilead-Public/gsm.reporting/issues/24
 dates <- names(ie_data) %>% as.Date
 reporting <- map2(reporting, dates, ~{
   .x$Reporting_Results$SnapshotDate <- .y

--- a/man/gsm.qtl-package.Rd
+++ b/man/gsm.qtl-package.Rd
@@ -11,9 +11,9 @@ The Good Statistical Monitoring or 'gsm' suite of R packages provides a framewor
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://gilead-biostats.github.io/gsm.qtl}
-  \item \url{https://github.com/Gilead-BioStats/gsm.qtl},
-  \item Report bugs at \url{https://github.com/Gilead-BioStats/gsm.qtl/issues}
+  \item \url{https://gilead-public.github.io/gsm.qtl}
+  \item \url{https://github.com/Gilead-Public/gsm.qtl,}
+  \item Report bugs at \url{https://github.com/Gilead-Public/gsm.qtl/issues}
 }
 
 }
@@ -22,7 +22,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Zhongkai Wang \email{Zhongkai.Wang6@gilead.com} (\href{https://orcid.org/0000-0002-1883-2265}{ORCID})
   \item Laura Maxwell \email{laura.maxwell@atorusresearch.com}
   \item Zelos Zhu \email{zelos.zhu@atorusresearch.com}
 }

--- a/pkgdown/menus/examples/Example_QTL.Rmd
+++ b/pkgdown/menus/examples/Example_QTL.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "QTL Report"
-author: "[gsm.qtl](https://gilead-biostats.github.io/gsm.qtl) Example"
+author: "[gsm.qtl](https://gilead-public.github.io/gsm.qtl) Example"
 description: "Example of a QTL Report generated using standard QTLs in gsm.kri"
 index: 1
 date: "`r format(Sys.time(), '%B %d, %Y %H:%M:%S %Z')`"

--- a/vignettes/articles/Qualification.Rmd
+++ b/vignettes/articles/Qualification.Rmd
@@ -24,7 +24,6 @@ suppressPackageStartupMessages({
   library(pander)
   library(gh)
   library(stringr)
-  library(riskmetric)
   suppressMessages(devtools::load_all())
 })
 

--- a/vignettes/articles/Qualification.Rmd
+++ b/vignettes/articles/Qualification.Rmd
@@ -194,20 +194,20 @@ pander::pandoc.p('\\pagebreak')
 
 # Pull Request History
 
-The GitHub Pull Request (PR) process begins with the creation of one or more issues that clearly define the proposed additions or revisions to the package. Each issue should be assigned to a product developer (PD) who then creates a `fix` branch named according to the related issue(s), and implements the necessary code updates. Once the work is complete, the PD opens a Pull Request to merge the `fix` branch into the target branch (typically the `dev` branch). They must assign the PR to themselves, request one or more reviewers, and link the PR to the associated issue(s). Before the fix branch can be merged, the PR must be approved by the designated reviewers and pass all required GitHub qualification checks. Once these conditions are met, the `fix` branch is merged into the target branch. This process is fully documented in the [Contributor Guidelines](https://gilead-biostats.github.io/gsm.core/articles/ContributorGuidelines.html#development-process)
+The GitHub Pull Request (PR) process begins with the creation of one or more issues that clearly define the proposed additions or revisions to the package. Each issue should be assigned to a product developer (PD) who then creates a `fix` branch named according to the related issue(s), and implements the necessary code updates. Once the work is complete, the PD opens a Pull Request to merge the `fix` branch into the target branch (typically the `dev` branch). They must assign the PR to themselves, request one or more reviewers, and link the PR to the associated issue(s). Before the fix branch can be merged, the PR must be approved by the designated reviewers and pass all required GitHub qualification checks. Once these conditions are met, the `fix` branch is merged into the target branch. This process is fully documented in the [Contributor Guidelines](https://gilead-public.github.io/gsm.core/articles/ContributorGuidelines.html#development-process)
 
 
 Below, the most recent 10 PRs into `r params$repo` are displayed. [See all Pull Requests here.](`r paste0("https://github.com/gilead-biostats/",params$repo,"/pulls")`)
 
 ```{r prs}
-release <- gh(paste0("/repos/Gilead-BioStats/",params$repo,"/releases"))[[1]]
+release <- gh(paste0("/repos/Gilead-Public/",params$repo,"/releases"))[[1]]
 release_date <- ifelse(is.null(release$published_at), release$created_at, release$published_at)
 
 pr_at_date <- FALSE
 page_num <- 1
 prs <- list()
 while(pr_at_date != TRUE){
-  resp <- gh(paste0("/repos/Gilead-BioStats/",params$repo,"/pulls"), per_page = 100,
+  resp <- gh(paste0("/repos/Gilead-Public/",params$repo,"/pulls"), per_page = 100,
              .params = list(page = page_num, state = "closed"))
 
   map(resp, function(x){
@@ -240,7 +240,7 @@ getRepoDetails <- function(x) {
   Link <- x[["html_url"]]
 
 
-  tempReviews <- gh(paste0("GET /repos/Gilead-BioStats/", params$repo, "/pulls/", PullRequest, "/reviews"))
+  tempReviews <- gh(paste0("GET /repos/Gilead-Public/", params$repo, "/pulls/", PullRequest, "/reviews"))
 
   if (length(tempReviews) > 0) {
   ReviewStatus <- tempReviews[[1]][["state"]]


### PR DESCRIPTION
# gsm.qtl v1.3.1

This patch release removes an unused dependency that had a dependency on the log4r package, because the log4r package was archived on CRAN (#124)